### PR TITLE
Replace non word characters from aggregation name

### DIFF
--- a/lib/elasticband/aggregation.rb
+++ b/lib/elasticband/aggregation.rb
@@ -7,7 +7,7 @@ module Elasticband
     attr_accessor :name
 
     def initialize(name)
-      self.name = name.to_sym
+      self.name = name.to_s.gsub(/\W/, '_').to_sym
     end
 
     def to_h(aggregation_hash = {})

--- a/spec/aggregation_spec.rb
+++ b/spec/aggregation_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe Elasticband::Aggregation do
 
       it { is_expected.to eq(aggregation_name: { key: :value }) }
     end
+
+    context 'with special chars' do
+      subject { described_class.new('aggregation.name').to_h }
+
+      it { is_expected.to eq(aggregation_name: {}) }
+    end
   end
 
   describe '.parse' do


### PR DESCRIPTION
Aggregation names with `.` can be misinterpreted, one case is when ordering terms aggregation (https://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-order)
