### PR TITLE
Add `max` aggregation and improve aggregation parsing

### DIFF
--- a/lib/elasticband.rb
+++ b/lib/elasticband.rb
@@ -1,7 +1,7 @@
-require 'active_support'
-require 'active_support/core_ext/object'
 require 'active_support/core_ext/array'
 require 'active_support/core_ext/hash'
+require 'active_support/core_ext/object'
+require 'active_support/json'
 
 require 'elasticband/aggregation'
 require 'elasticband/filter'

--- a/lib/elasticband.rb
+++ b/lib/elasticband.rb
@@ -1,6 +1,7 @@
 require 'active_support'
 require 'active_support/core_ext/object'
 require 'active_support/core_ext/array'
+require 'active_support/core_ext/hash'
 
 require 'elasticband/aggregation'
 require 'elasticband/filter'

--- a/lib/elasticband/aggregation.rb
+++ b/lib/elasticband/aggregation.rb
@@ -43,7 +43,11 @@ module Elasticband
       # Aggregation.parse(group_by: [:status, size: 5, top_hits: 3])
       # => { status: { terms: { field: :status, size: 5 }, aggs: { top_status: { top_hits: 3 } } } }
       def parse(options)
-        parse_aggregations(options).each_with_object({}) { |a, h| h.merge!(a.to_h) }
+        merge(*parse_aggregations(options))
+      end
+
+      def merge(*aggregations)
+        aggregations.each_with_object({}) { |a, h| h.merge!(a.to_h) }
       end
 
       private

--- a/lib/elasticband/aggregation.rb
+++ b/lib/elasticband/aggregation.rb
@@ -1,3 +1,4 @@
+require 'elasticband/aggregation/max'
 require 'elasticband/aggregation/nested'
 require 'elasticband/aggregation/terms'
 require 'elasticband/aggregation/top_hits'

--- a/lib/elasticband/aggregation.rb
+++ b/lib/elasticband/aggregation.rb
@@ -1,3 +1,4 @@
+require 'elasticband/aggregation/field_based'
 require 'elasticband/aggregation/max'
 require 'elasticband/aggregation/nested'
 require 'elasticband/aggregation/terms'

--- a/lib/elasticband/aggregation/field_based.rb
+++ b/lib/elasticband/aggregation/field_based.rb
@@ -1,0 +1,27 @@
+module Elasticband
+  class Aggregation
+    class FieldBased < Aggregation
+      attr_accessor :field, :options
+
+      def initialize(name, field, options = {})
+        super(name)
+        self.field = field && field.to_sym
+        self.options = options
+      end
+
+      def to_h
+        super(aggregation_hash)
+      end
+
+      def type
+        fail NotImplementedError
+      end
+
+      private
+
+      def aggregation_hash
+        { type => { field: field }.merge!(options).compact }
+      end
+    end
+  end
+end

--- a/lib/elasticband/aggregation/max.rb
+++ b/lib/elasticband/aggregation/max.rb
@@ -1,22 +1,8 @@
 module Elasticband
   class Aggregation
-    class Max < Aggregation
-      attr_accessor :field, :options
-
-      def initialize(name, field, options = {})
-        super(name)
-        self.field = field.to_sym if field
-        self.options = options
-      end
-
-      def to_h
-        super(aggregation_hash)
-      end
-
-      private
-
-      def aggregation_hash
-        { max: { field: field }.merge!(options).compact }
+    class Max < FieldBased
+      def type
+        :max
       end
     end
   end

--- a/lib/elasticband/aggregation/max.rb
+++ b/lib/elasticband/aggregation/max.rb
@@ -1,0 +1,23 @@
+module Elasticband
+  class Aggregation
+    class Max < Aggregation
+      attr_accessor :field, :options
+
+      def initialize(name, field, options = {})
+        super(name)
+        self.field = field.to_sym if field
+        self.options = options
+      end
+
+      def to_h
+        super(aggregation_hash)
+      end
+
+      private
+
+      def aggregation_hash
+        { max: { field: field }.merge!(options).compact }
+      end
+    end
+  end
+end

--- a/lib/elasticband/aggregation/nested.rb
+++ b/lib/elasticband/aggregation/nested.rb
@@ -17,7 +17,7 @@ module Elasticband
       private
 
       def nested_hash
-        nested_aggregations.each_with_object({}) { |a, h| h.merge!(a.to_h) }
+        self.class.merge(*nested_aggregations)
       end
     end
   end

--- a/lib/elasticband/aggregation/nested.rb
+++ b/lib/elasticband/aggregation/nested.rb
@@ -1,17 +1,23 @@
 module Elasticband
   class Aggregation
     class Nested < Aggregation
-      attr_accessor :root_aggregation, :nested_aggregation
+      attr_accessor :root_aggregation, :nested_aggregations
 
-      def initialize(root_aggregation, nested_aggregation)
+      def initialize(root_aggregation, nested_aggregations)
         self.root_aggregation = root_aggregation
-        self.nested_aggregation = nested_aggregation
+        self.nested_aggregations = Array.wrap(nested_aggregations)
       end
 
       def to_h
         root_aggregation.to_h.tap do |h|
-          h[root_aggregation.name].merge!(aggs: nested_aggregation.to_h)
+          h[root_aggregation.name].merge!(aggs: nested_hash)
         end
+      end
+
+      private
+
+      def nested_hash
+        nested_aggregations.each_with_object({}) { |a, h| h.merge!(a.to_h) }
       end
     end
   end

--- a/lib/elasticband/aggregation/terms.rb
+++ b/lib/elasticband/aggregation/terms.rb
@@ -5,7 +5,7 @@ module Elasticband
 
       def initialize(name, field, options = {})
         super(name)
-        self.field = field.to_sym
+        self.field = field.to_sym if field
         self.options = options
       end
 
@@ -16,7 +16,7 @@ module Elasticband
       private
 
       def aggregation_hash
-        { terms: { field: field }.merge!(options) }
+        { terms: { field: field }.merge!(options).compact }
       end
     end
   end

--- a/lib/elasticband/aggregation/terms.rb
+++ b/lib/elasticband/aggregation/terms.rb
@@ -1,22 +1,8 @@
 module Elasticband
   class Aggregation
-    class Terms < Aggregation
-      attr_accessor :field, :options
-
-      def initialize(name, field, options = {})
-        super(name)
-        self.field = field.to_sym if field
-        self.options = options
-      end
-
-      def to_h
-        super(aggregation_hash)
-      end
-
-      private
-
-      def aggregation_hash
-        { terms: { field: field }.merge!(options).compact }
+    class Terms < FieldBased
+      def type
+        :terms
       end
     end
   end

--- a/lib/elasticband/aggregation/top_hits.rb
+++ b/lib/elasticband/aggregation/top_hits.rb
@@ -1,19 +1,16 @@
 module Elasticband
   class Aggregation
     class TopHits < Aggregation
-      attr_accessor :root_aggregation, :size, :from, :options
+      attr_accessor :size, :options
 
-      def initialize(name, root_aggregation, size, options = {})
+      def initialize(name, size, options = {})
         super(name)
-        self.root_aggregation = root_aggregation
         self.size = size
         self.options = options
       end
 
       def to_h
-        root_aggregation.to_h.tap do |h|
-          h[root_aggregation.name].merge!(aggs: super(top_hits_hash))
-        end
+        super(top_hits_hash)
       end
 
       private

--- a/spec/aggregation/field_based_spec.rb
+++ b/spec/aggregation/field_based_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe Elasticband::Aggregation::FieldBased do
+  describe '#type' do
+    subject { described_class.new(:aggregation_name, :field_name).type }
+
+    it { expect { subject }.to raise_error(NotImplementedError) }
+  end
+
+  describe '#to_h' do
+    subject { aggregation.to_h }
+
+    before { allow(aggregation).to receive(:type) { :aggregation_type } }
+
+    context 'without options' do
+      let(:aggregation) { described_class.new(:aggregation_name, :field_name) }
+
+      it { is_expected.to eq(aggregation_name: { aggregation_type: { field: :field_name } }) }
+    end
+
+    context 'with options' do
+      context 'with field' do
+        let(:aggregation) { described_class.new(:aggregation_name, :field_name, size: 1) }
+
+        it { is_expected.to eq(aggregation_name: { aggregation_type: { field: :field_name, size: 1 } }) }
+      end
+
+      context 'without field' do
+        let(:aggregation) { described_class.new(:aggregation_name, nil, script: "doc['price'].value") }
+
+        it { is_expected.to eq(aggregation_name: { aggregation_type: { script: "doc['price'].value" } }) }
+      end
+    end
+  end
+end

--- a/spec/aggregation/max_spec.rb
+++ b/spec/aggregation/max_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Elasticband::Aggregation::Max do
+  describe '#to_h' do
+    context 'without options' do
+      subject { described_class.new(:aggregation_name, :field_name).to_h }
+
+      it { is_expected.to eq(aggregation_name: { max: { field: :field_name } }) }
+    end
+
+    context 'with options' do
+      context 'with field' do
+        subject { described_class.new(:aggregation_name, :field_name, script: '_value * 1.2').to_h }
+
+        it { is_expected.to eq(aggregation_name: { max: { field: :field_name, script: '_value * 1.2' } }) }
+      end
+
+      context 'without field' do
+        subject { described_class.new(:aggregation_name, nil, script: 'doc.score').to_h }
+
+        it { is_expected.to eq(aggregation_name: { max: { script: 'doc.score' } }) }
+      end
+    end
+  end
+end

--- a/spec/aggregation/max_spec.rb
+++ b/spec/aggregation/max_spec.rb
@@ -1,25 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe Elasticband::Aggregation::Max do
-  describe '#to_h' do
-    context 'without options' do
-      subject { described_class.new(:aggregation_name, :field_name).to_h }
+  describe '#type' do
+    subject { described_class.new(:aggregation_name, :field_name).type }
 
-      it { is_expected.to eq(aggregation_name: { max: { field: :field_name } }) }
-    end
-
-    context 'with options' do
-      context 'with field' do
-        subject { described_class.new(:aggregation_name, :field_name, script: '_value * 1.2').to_h }
-
-        it { is_expected.to eq(aggregation_name: { max: { field: :field_name, script: '_value * 1.2' } }) }
-      end
-
-      context 'without field' do
-        subject { described_class.new(:aggregation_name, nil, script: 'doc.score').to_h }
-
-        it { is_expected.to eq(aggregation_name: { max: { script: 'doc.score' } }) }
-      end
-    end
+    it { is_expected.to eq(:max) }
   end
 end

--- a/spec/aggregation/nested_spec.rb
+++ b/spec/aggregation/nested_spec.rb
@@ -2,27 +2,52 @@ require 'spec_helper'
 
 RSpec.describe Elasticband::Aggregation::Nested do
   describe '#to_h' do
-    subject { described_class.new(root_aggregation, nested_aggregation).to_h }
-
     let(:root_aggregation) { Elasticband::Aggregation.new(:root_aggregation) }
-    let(:nested_aggregation) { Elasticband::Aggregation.new(:nested_aggregation) }
+    let(:nested_aggregation_1) { Elasticband::Aggregation.new(:nested_aggregation_1) }
+    let(:nested_aggregation_2) { Elasticband::Aggregation.new(:nested_aggregation_2) }
+    let(:nested_aggregations) { [nested_aggregation_1, nested_aggregation_2] }
 
     before do
-      allow(root_aggregation).to receive(:to_h) { { root_aggregation: { key_1: :value_1 } } }
-      allow(nested_aggregation).to receive(:to_h) { { nested_aggregation: { key_2: :value_2 } } }
+      allow(nested_aggregation_1).to receive(:to_h) { { nested_aggregation_1: { key_1: :value_1 } } }
+      allow(nested_aggregation_2).to receive(:to_h) { { nested_aggregation_2: { key_2: :value_2 } } }
+      allow(root_aggregation).to receive(:to_h) { { root_aggregation: { key: :value } } }
     end
 
-    it 'returns a nested aggreagation hash' do
-      is_expected.to eq(
-        root_aggregation: {
-          key_1: :value_1,
-          aggs: {
-            nested_aggregation: {
-              key_2: :value_2
+    context 'with one aggregation' do
+      subject { described_class.new(root_aggregation, nested_aggregation_1).to_h }
+
+      it 'returns a nested aggreagation hash' do
+        is_expected.to eq(
+          root_aggregation: {
+            key: :value,
+            aggs: {
+              nested_aggregation_1: {
+                key_1: :value_1
+              }
             }
           }
-        }
-      )
+        )
+      end
+    end
+
+    context 'with two aggregations' do
+      subject { described_class.new(root_aggregation, nested_aggregations).to_h }
+
+      it 'returns a nested aggreagation hash' do
+        is_expected.to eq(
+          root_aggregation: {
+            key: :value,
+            aggs: {
+              nested_aggregation_1: {
+                key_1: :value_1
+              },
+              nested_aggregation_2: {
+                key_2: :value_2
+              }
+            }
+          }
+        )
+      end
     end
   end
 end

--- a/spec/aggregation/terms_spec.rb
+++ b/spec/aggregation/terms_spec.rb
@@ -1,25 +1,9 @@
 require 'spec_helper'
 
 RSpec.describe Elasticband::Aggregation::Terms do
-  describe '#to_h' do
-    context 'without options' do
-      subject { described_class.new(:aggregation_name, :field_name).to_h }
+  describe '#type' do
+    subject { described_class.new(:aggregation_name, :field_name).type }
 
-      it { is_expected.to eq(aggregation_name: { terms: { field: :field_name } }) }
-    end
-
-    context 'with options' do
-      context 'with field' do
-        subject { described_class.new(:aggregation_name, :field_name, size: 1).to_h }
-
-        it { is_expected.to eq(aggregation_name: { terms: { field: :field_name, size: 1 } }) }
-      end
-
-      context 'without field' do
-        subject { described_class.new(:aggregation_name, nil, script: "doc['field_name'].value").to_h }
-
-        it { is_expected.to eq(aggregation_name: { terms: { script: "doc['field_name'].value" } }) }
-      end
-    end
+    it { is_expected.to eq(:terms) }
   end
 end

--- a/spec/aggregation/terms_spec.rb
+++ b/spec/aggregation/terms_spec.rb
@@ -9,9 +9,17 @@ RSpec.describe Elasticband::Aggregation::Terms do
     end
 
     context 'with options' do
-      subject { described_class.new(:aggregation_name, :field_name, size: 1).to_h }
+      context 'with field' do
+        subject { described_class.new(:aggregation_name, :field_name, size: 1).to_h }
 
-      it { is_expected.to eq(aggregation_name: { terms: { field: :field_name, size: 1 } }) }
+        it { is_expected.to eq(aggregation_name: { terms: { field: :field_name, size: 1 } }) }
+      end
+
+      context 'without field' do
+        subject { described_class.new(:aggregation_name, nil, script: "doc['field_name'].value").to_h }
+
+        it { is_expected.to eq(aggregation_name: { terms: { script: "doc['field_name'].value" } }) }
+      end
     end
   end
 end

--- a/spec/aggregation/top_hits_spec.rb
+++ b/spec/aggregation/top_hits_spec.rb
@@ -2,25 +2,16 @@ require 'spec_helper'
 
 RSpec.describe Elasticband::Aggregation::TopHits do
   describe '#to_h' do
-    subject { described_class.new(:top_hits_aggregation, root_aggregation, 3).to_h }
+    context 'without options' do
+      subject { described_class.new(:top_hits_aggregation, 3).to_h }
 
-    let(:root_aggregation) { Elasticband::Aggregation.new(:root_aggregation) }
-
-    before do
-      allow(root_aggregation).to receive(:to_h) { { root_aggregation: { terms: { field: :field_name } } } }
+      it { is_expected.to eq(top_hits_aggregation: { top_hits: { size: 3 } }) }
     end
 
-    it 'returns a nested aggreagation hash' do
-      is_expected.to eq(
-        root_aggregation: {
-          terms: { field: :field_name },
-          aggs: {
-            top_hits_aggregation: {
-              top_hits: { size: 3 }
-            }
-          }
-        }
-      )
+    context 'with options' do
+      subject { described_class.new(:top_hits_aggregation, 3, cache: true).to_h }
+
+      it { is_expected.to eq(top_hits_aggregation: { top_hits: { size: 3, cache: true } }) }
     end
   end
 end

--- a/spec/aggregation_spec.rb
+++ b/spec/aggregation_spec.rb
@@ -76,4 +76,23 @@ RSpec.describe Elasticband::Aggregation do
       end
     end
   end
+
+  describe '.merge' do
+    subject { described_class.merge(aggregation_1, aggregation_2) }
+
+    let(:aggregation_1) { Elasticband::Aggregation.new(:aggregation_1) }
+    let(:aggregation_2) { Elasticband::Aggregation.new(:aggregation_2) }
+
+    before do
+      allow(aggregation_1).to receive(:to_h) { { aggregation_1: { key_1: :value_1 } } }
+      allow(aggregation_2).to receive(:to_h) { { aggregation_2: { key_2: :value_2 } } }
+    end
+
+    it 'returns a hash with all aggregations' do
+      is_expected.to eq(
+        aggregation_1: { key_1: :value_1 },
+        aggregation_2: { key_2: :value_2 }
+      )
+    end
+  end
 end

--- a/spec/aggregation_spec.rb
+++ b/spec/aggregation_spec.rb
@@ -28,17 +28,17 @@ RSpec.describe Elasticband::Aggregation do
       context 'with the field_name' do
         let(:options) { { group_by: :status } }
 
-        it { is_expected.to eq(status: { terms: { field: :status } }) }
+        it { is_expected.to eq(by_status: { terms: { field: :status } }) }
       end
 
-      context 'with an array with field_name and :top_hits option' do
+      context 'with an array with field_name and other aggregation' do
         let(:options) { { group_by: [:status, top_hits: 3] } }
 
         it 'returns the `terms` aggregation with a `top_hits` nested' do
           is_expected.to eq(
-            status: {
+            by_status: {
               terms: { field: :status },
-              aggs: { top_status: { top_hits: { size: 3 } } }
+              aggs: { top_by_status: { top_hits: { size: 3 } } }
             }
           )
         end
@@ -47,7 +47,32 @@ RSpec.describe Elasticband::Aggregation do
       context 'with an array with field_name and other options' do
         let(:options) { { group_by: [:status, size: 3] } }
 
-        it { is_expected.to eq(status: { terms: { field: :status, size: 3 } }) }
+        it { is_expected.to eq(by_status: { terms: { field: :status, size: 3 } }) }
+      end
+    end
+
+    context 'with `:group_max` option' do
+      context 'with the field_name' do
+        let(:options) { { group_max: :price } }
+
+        it { is_expected.to eq(max_price: { max: { field: :price } }) }
+      end
+
+      context 'with an array with field_name and options' do
+        let(:options) { { group_max: [:price, script: '_value * 1.2'] } }
+
+        it { is_expected.to eq(max_price: { max: { field: :price, script: '_value * 1.2' } }) }
+      end
+    end
+
+    context 'with more than one aggregation' do
+      let(:options) { { group_by: :status, group_max: :price } }
+
+      it 'returns a hash with all aggregations' do
+        is_expected.to eq(
+          by_status: { terms: { field: :status } },
+          max_price: { max: { field: :price } }
+        )
       end
     end
   end


### PR DESCRIPTION
- Add `Max` aggregation
- Allow field nil for `Terms` aggregation
- Add option `group_max` to `Aggregation.parse`:
  - Allow nested aggregations on parse
  - Allow more than one aggregation
