### PR TITLE
Add Filter aggregation

### DIFF
--- a/lib/elasticband/aggregation.rb
+++ b/lib/elasticband/aggregation.rb
@@ -1,4 +1,5 @@
 require 'elasticband/aggregation/field_based'
+require 'elasticband/aggregation/filter'
 require 'elasticband/aggregation/max'
 require 'elasticband/aggregation/nested'
 require 'elasticband/aggregation/terms'

--- a/lib/elasticband/aggregation/filter.rb
+++ b/lib/elasticband/aggregation/filter.rb
@@ -1,0 +1,23 @@
+module Elasticband
+  class Aggregation
+    class Filter < Aggregation
+      attr_accessor :filter, :options
+
+      def initialize(name, filter, options = {})
+        super(name)
+        self.filter = filter
+        self.options = options
+      end
+
+      def to_h
+        super(aggregation_hash)
+      end
+
+      private
+
+      def aggregation_hash
+        { filter: filter.to_h }.merge!(options)
+      end
+    end
+  end
+end

--- a/lib/elasticband/filter.rb
+++ b/lib/elasticband/filter.rb
@@ -6,6 +6,8 @@ require 'elasticband/filter/terms'
 
 module Elasticband
   class Filter
+    PARSE_FILTERS = %i(only except includes)
+
     def to_h
       { match_all: {} }
     end

--- a/spec/aggregation/filter_spec.rb
+++ b/spec/aggregation/filter_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe Elasticband::Aggregation::Filter do
+  describe '#to_h' do
+    let(:filter) { Elasticband::Filter.new }
+
+    before { allow(filter).to receive(:to_h) { 'filter' } }
+
+    context 'without options' do
+      subject { described_class.new(:aggregation_name, filter).to_h }
+
+      it { is_expected.to eq(aggregation_name: { filter: 'filter' }) }
+    end
+
+    context 'with options' do
+      subject { described_class.new(:aggregation_name, filter, _cache: true).to_h }
+
+      it { is_expected.to eq(aggregation_name: { filter: 'filter', _cache: true }) }
+    end
+  end
+end

--- a/spec/aggregation_spec.rb
+++ b/spec/aggregation_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe Elasticband::Aggregation do
       end
     end
 
+    context 'with `:group_by_filter` option' do
+      let(:options) { { group_by_filter: [:published_results, filter_options] } }
+      let(:filter_options) { { only: { status: :published } } }
+
+      before { expect(Elasticband::Filter).to receive(:parse).with(filter_options) { { name: 'filter' } } }
+
+      it { is_expected.to eq(published_results: { filter: { name: 'filter' } }) }
+    end
+
     context 'with more than one aggregation' do
       let(:options) { { group_by: :status, group_max: :price } }
 


### PR DESCRIPTION
Add filter aggregation parsing as `group_by_filter` option (ref https://www.elastic.co/guide/en/elasticsearch/reference/1.6/search-aggregations-bucket-filter-aggregation.html)
