### PR TITLE
Add `missing` option to `boost_by`

### DIFF
--- a/lib/elasticband/query.rb
+++ b/lib/elasticband/query.rb
@@ -93,7 +93,7 @@ module Elasticband
 
       def parse_boost_function(boost_options)
         if boost_options[:boost_by].present?
-          ScoreFunction::FieldValueFactor.new(boost_options[:boost_by], modifier: :ln2p)
+          ScoreFunction::FieldValueFactor.new(boost_options[:boost_by], modifier: :ln2p, missing: 1)
         elsif boost_options[:boost_where].present?
           filter = Filter.parse(only: boost_options[:boost_where])
           ScoreFunction::Filtered.new(filter, ScoreFunction::BoostFactor.new(1_000))

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe Elasticband::Query do
               query: { match: { _all: 'foo' } },
               field_value_factor: {
                 field: :contents_count,
-                modifier: :ln2p
+                modifier: :ln2p,
+                missing: 1
               }
             }
           )


### PR DESCRIPTION
This adds a default value if the object does not have the field.

> Value used if the document doesn’t have that field. The modifier and factor are still applied to it as though it were read from the document.
