### PR TITLE
Reverting `missing` option to `boost_by`

### DIFF
--- a/lib/elasticband/query.rb
+++ b/lib/elasticband/query.rb
@@ -93,7 +93,7 @@ module Elasticband
 
       def parse_boost_function(boost_options)
         if boost_options[:boost_by].present?
-          ScoreFunction::FieldValueFactor.new(boost_options[:boost_by], modifier: :ln2p, missing: 1)
+          ScoreFunction::FieldValueFactor.new(boost_options[:boost_by], modifier: :ln2p)
         elsif boost_options[:boost_where].present?
           filter = Filter.parse(only: boost_options[:boost_where])
           ScoreFunction::Filtered.new(filter, ScoreFunction::BoostFactor.new(1_000))

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -62,8 +62,7 @@ RSpec.describe Elasticband::Query do
               query: { match: { _all: 'foo' } },
               field_value_factor: {
                 field: :contents_count,
-                modifier: :ln2p,
-                missing: 1
+                modifier: :ln2p
               }
             }
           )


### PR DESCRIPTION
Reverting https://github.com/LoveMondays/elasticband/pull/7

due to the bug on:
closes https://github.com/LoveMondays/love-mondays/issues/3129
