### PR TITLE
Add script filter

### DIFF
--- a/lib/elasticband/filter/script.rb
+++ b/lib/elasticband/filter/script.rb
@@ -1,0 +1,26 @@
+module Elasticband
+  class Filter
+    class Script < Filter
+      attr_accessor :script, :params
+
+      def initialize(script, params = {})
+        self.script = script
+        self.params = params
+      end
+
+      def to_h
+        return {} unless script
+
+        { script: { script: script }.merge(params_hash) }
+      end
+
+      private
+
+      def params_hash
+        return {} unless params.any?
+
+        { params: params }
+      end
+    end
+  end
+end

--- a/lib/elasticband/version.rb
+++ b/lib/elasticband/version.rb
@@ -1,3 +1,3 @@
 module Elasticband
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/filter/script_spec.rb
+++ b/spec/filter/script_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe Elasticband::Filter::Script do
+  describe '#to_h' do
+    context 'without params' do
+      subject { described_class.new('(param1 + param2) > 0').to_h }
+
+      it { is_expected.to eq(script: { script: '(param1 + param2) > 0' }) }
+    end
+
+    context 'with params' do
+      subject { described_class.new('(param1 + param2) > 0', param1: 1, param2: 1).to_h }
+
+      it { is_expected.to eq(script: { script: '(param1 + param2) > 0', params: { param1: 1, param2: 1 } }) }
+    end
+  end
+end

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -104,5 +104,12 @@ RSpec.describe Elasticband::Filter do
 
       it { is_expected.to eq(filter) }
     end
+
+    context 'with `:script` option' do
+      let(:options) { { script: ['(param1 + param2) > 0', param1: 1, param2: 1] } }
+      let(:filter) { { script: { script: '(param1 + param2) > 0', params: { param1: 1, param2: 1 } } } }
+
+      it { is_expected.to eq(filter) }
+    end
   end
 end


### PR DESCRIPTION
- [x] Add script filtering

This way we can pass a script with parameters so that we can define any match function to filter our data as we want.

On a practical example, when we search through multiple models, and we want to filter only one model by a field which has the same name on both, we can do that by first verifying if the record is from the model we want, and then check the condition only on that model.
